### PR TITLE
Fix time display

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 REACT_APP_SPACEX_API_URL=https://api.spacexdata.com/v3
+REACT_APP_GOOGLE_API_KEY="AIzaSyCTIaQWVtEOR-cFBdPe02tpayJTyp_qmpk"

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -27,7 +27,6 @@ import { useSpaceX } from "../utils/use-space-x";
 import { formatDateTime } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
-import enUS from "date-fns/esm/locale/en-US/index.js";
 
 
 export default function Launch() {

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -25,6 +25,7 @@ import {
 
 import { useSpaceX } from "../utils/use-space-x";
 import { formatDateTime } from "../utils/format-date";
+import {useTimeZoneFinder } from "../utils/timeZone";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
@@ -117,10 +118,8 @@ function Header({ launch }) {
 }
 
 function TimeAndLocation({ launch }) {
-  let timeZone;
-  if (launch.launch_date_local.slice(-5) === "08:00") timeZone = "America/Los_Angeles"
-  if (launch.launch_date_local.slice(-5) === "04:00") timeZone = "America/New_York"
-
+  let timeZone = useTimeZoneFinder (launch.launch_site.site_id)
+  
   return (
     <SimpleGrid columns={[1, 1, 2]} borderWidth="1px" p="4" borderRadius="md">
       <Stat>

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,16 +19,20 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
+  Tooltip,
 } from "@chakra-ui/core";
+
 
 import { useSpaceX } from "../utils/use-space-x";
 import { formatDateTime } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
+import enUS from "date-fns/esm/locale/en-US/index.js";
+
 
 export default function Launch() {
   let { launchId } = useParams();
-  const { data: launch, error } = useSpaceX(`/launches/${launchId}`);
+  const { data: launch, error } = useSpaceX(`/launches/${launchId}`)
 
   if (error) return <Error />;
   if (!launch) {
@@ -114,6 +118,10 @@ function Header({ launch }) {
 }
 
 function TimeAndLocation({ launch }) {
+  let timeZone;
+  if (launch.launch_date_local.slice(-5) === "08:00") timeZone = "America/Los_Angeles"
+  if (launch.launch_date_local.slice(-5) === "04:00") timeZone = "America/New_York"
+
   return (
     <SimpleGrid columns={[1, 1, 2]} borderWidth="1px" p="4" borderRadius="md">
       <Stat>
@@ -122,11 +130,13 @@ function TimeAndLocation({ launch }) {
           <Box ml="2" as="span">
             Launch Date
           </Box>
-        </StatLabel>
-        <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
-        </StatNumber>
-        <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
+        </StatLabel> 
+          <StatNumber fontSize={["md", "xl"]}>
+           <Tooltip label={formatDateTime(launch.launch_date_utc)} placement="top-end" hasArrow >
+            {formatDateTime(launch.launch_date_local, timeZone)}
+            </Tooltip>
+          </StatNumber>
+         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>
       <Stat>
         <StatLabel display="flex">

--- a/src/components/launches.js
+++ b/src/components/launches.js
@@ -4,14 +4,15 @@ import { format as timeAgo } from "timeago.js";
 import { Link } from "react-router-dom";
 
 import { useSpaceXPaginated } from "../utils/use-space-x";
+
 import { formatDate } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import LoadMoreButton from "./load-more-button";
-
 const PAGE_SIZE = 12;
 
 export default function Launches() {
+
   const { data, error, isValidating, setSize, size } = useSpaceXPaginated(
     "/launches/past",
     {
@@ -21,6 +22,7 @@ export default function Launches() {
     }
   );
   console.log(data, error);
+  
   return (
     <div>
       <Breadcrumbs

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -7,7 +7,7 @@ export function formatDate(timestamp) {
   }).format(new Date(timestamp));
 }
 
-export function formatDateTime(timestamp) {
+export function formatDateTime(timestamp, timeZone) {
   return new Intl.DateTimeFormat("en-US", {
     year: "numeric",
     month: "long",
@@ -16,5 +16,6 @@ export function formatDateTime(timestamp) {
     minute: "numeric",
     second: "numeric",
     timeZoneName: "short",
+    timeZone:timeZone,
   }).format(new Date(timestamp));
 }

--- a/src/utils/timeZone.js
+++ b/src/utils/timeZone.js
@@ -1,0 +1,23 @@
+import useSWR from "swr";
+import { useSpaceX, fetcher } from "../utils/use-space-x";
+
+
+export const useTimeZoneFinder = (siteId)=>{
+  const {data} =  useSpaceX("/launchpads");
+  const site = data?.find((launchPad)=> launchPad.site_id === siteId);
+  const latitude = site?.location.latitude
+  const longitude  = site?.location.longitude
+  const APIresponse = useSWR(latitude && longitude ?`https://maps.googleapis.com/maps/api/timezone/json?location=${latitude},${longitude}&timestamp=1331766000&key=${process.env.REACT_APP_GOOGLE_API_KEY}`:null,fetcher)
+  if(APIresponse.data?.errorMessage) console.log(APIresponse.data)
+  return APIresponse.data?.timeZoneId
+}
+
+
+
+
+ 
+
+
+ 
+
+  

--- a/src/utils/use-space-x.js
+++ b/src/utils/use-space-x.js
@@ -1,6 +1,6 @@
 import useSWR, { useSWRInfinite } from "swr";
 
-const fetcher = async (...args) => {
+export const fetcher = async (...args) => {
   const response = await fetch(...args);
   if (!response.ok) {
     throw Error(response.statusText);


### PR DESCRIPTION
**Bug** 

The launch datetime on the launch details page (e.g. /launches/92) is displayed in the timezone of the app's user. We need to show it in the local timezone of the launch site instead (still displaying the timezone name or offset) but still show the time in the user's timezone as a tooltip when hovering the timestamp. 

**Solution** 

We can get the location information from the api call (https://api.spacexdata.com/v3/launches), including the site_id. Thanks to another api call (https://api.spacexdata.com/v3/launchpads), we can get the coordinates of each site, given their side_id. 
I used google timeZone API to find the timezone name based on the coordinates of the launch pad, and build a hook called TimeZone.js.

